### PR TITLE
grunt dist - copy image files

### DIFF
--- a/app/templates/_Gruntfile.coffee
+++ b/app/templates/_Gruntfile.coffee
@@ -83,7 +83,10 @@ module.exports = (grunt) ->
                     dest: 'dist/'
                 },{
                     expand: true
-                    src: ['index.html']
+                    src: [
+                        'index.html',
+                        '{,*/}*.{gif,jpeg,jpg,png,svg,webp}'
+                    ]
                     dest: 'dist/'
                     filter: 'isFile'
                 }]


### PR DESCRIPTION
Without this, if I e.g. keep my images in an _img/_ folder, they won't get copied over to the _dist/_ folder.
