### PR TITLE
Added data-charset=utf-8 on sections

### DIFF
--- a/app/templates/__section.html
+++ b/app/templates/__section.html
@@ -1,5 +1,5 @@
 <%% if (!_.isString(slide) && !_.isArray(slide) && _.isObject(slide)) { %>
-    <section <%%= _.map(slide.attr, function (val, attr) {return attr + '="' + val + '"'}).join(' ')%> <%% if (_.isString(slide.filename)) { %>data-<%% if (slide.filename.indexOf('.html') !== -1) { %>html<%% } else { %>markdown<%% }%>="slides/<%%= slide.filename %>"<%% } %>></section>
+    <section <%%= _.map(slide.attr, function (val, attr) {return attr + '="' + val + '"'}).join(' ')%> <%% if (_.isString(slide.filename)) { %>data-<%% if (slide.filename.indexOf('.html') !== -1) { %>html<%% } else { %>markdown<%% }%>="slides/<%%= slide.filename %>"<%% } %> data-charset="utf-8"></section>
 <%% } %><%% if (_.isString(slide)) { %>
-    <section data-<%% if (slide.indexOf('.html') !== -1) { %>html<%% } else { %>markdown<%% }%>="slides/<%%= slide %>"></section>
+    <section data-<%% if (slide.indexOf('.html') !== -1) { %>html<%% } else { %>markdown<%% }%>="slides/<%%= slide %>" data-charset="utf-8"></section>
 <%% } %>


### PR DESCRIPTION
Hi Slara,

Thx for your great generator that I use a lot.

While sharing some of my pres, I've found an issue on UTF-8 when the pres is deployed on a public dropbox. Adding a simple `data-charset="utf-8"` on the `section` tag did the trick.

Here's the associated PR.

PEM
