### PR TITLE
Mark xhr.status=0 as successful

### DIFF
--- a/app/templates/loadhtmlslides.js
+++ b/app/templates/loadhtmlslides.js
@@ -17,7 +17,10 @@
                     url = section.getAttribute('data-html'),
                     cb = function () {
                         if (xhr.readyState === 4) {
-                            if (xhr.status >= 200 && xhr.status < 300) {
+                            if (
+                                (xhr.status >= 200 && xhr.status < 300) ||
+                                xhr.status === 0 // file protocol yields status code 0 (useful for local debug, mobile applications etc.)
+                                ) {
                                 section.innerHTML = xhr.responseText;
                             } else {
                                 section.outerHTML = '<section data-state="alert">ERROR: The attempt to fetch ' + url + ' failed with the HTTP status ' + xhr.status + '. Check your browser\'s JavaScript console for more details.</p></section>';


### PR DESCRIPTION
File protocol yields status code 0.
To support reveal on mobile application created using Phonegap/Cordova and for local debugging- xhr.status=0 should be marked as successful.

jQuery uses the same concept:
http://code.jquery.com/jquery-2.0.1.js

``` javascript
xhrSuccessStatus = {
        // file protocol always yields status code 0, assume 200
        0: 200,
```
