### PR TITLE
Update gitignore for dist to gh pages

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,5 +1,5 @@
 node_modules
-bower_components
+/bower_components
 dist
 *.log
 .sass-cache


### PR DESCRIPTION
When you build to the dist folder then push to gh pages the bower components will not be included as they are being ignored.

If we only ignore the root bower components then the dist copy of the bower components will be included and the github pages will work correctly.

The root bower components will still be excluded and have to  `npm i` as usual.
