### PR TITLE
ignore index.html

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,3 +1,4 @@
 node_modules
 bower_components
 *.log
+index.html


### PR DESCRIPTION
When using `grunt server` an `index.html` is generated in the root directory. Because this file is generated it should not be added to the repository.

This pull request ignores the generated `index.html`.
