### PR TITLE
Fix whitespace issue in _Gruntfile template

### DIFF
--- a/app/templates/_Gruntfile.coffee
+++ b/app/templates/_Gruntfile.coffee
@@ -91,7 +91,7 @@ module.exports = (grunt) ->
         <% if (config.get('deployToGithubPages')) { %>
         buildcontrol:
 
-             options:
+            options:
                 dir: 'dist'
                 commit: true
                 push: true


### PR DESCRIPTION
Here is what I got when using `grunt deploy`: 

Running "coffeelint:all" (coffeelint) task

Gruntfile.coffee
  ✖  line 94   Line contains inconsistent indentation  Expected 4 got 5
  ✖  line 95   Line contains inconsistent indentation  Expected 4 got 3
  ✖  line 100  Line contains inconsistent indentation  Expected 4 got 8

✖ 3 errors

Warning: Task "coffeelint:all" failed. Use --force to continue.
