### PR TITLE
Added dependency to reveal-highlight-themes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,5 +183,16 @@ whenever a new grunt build is triggered.
 You should instead edit the `templates/_index.html` file, which is used as a
 template for the automatically generated `index.html`.
 
+### Highlight.js Syntax Themes
+
+The generated presentation app includes the [Highlight.js Syntax Themes for Reveal.js](https://github.com/nwinkler/reveal-highlight-themes) as a dependency, allowing you to change the syntax theme.
+
+The available syntax themes can be found in the `bower_components/reveal-highlight-themes` folder. Selecting a new syntax theme can be done by changing the stylesheet reference in the `templates/_index.html` file:
+
+```html
+<!-- For syntax highlighting -->
+<link rel="stylesheet" href="bower_components/reveal-highlight-themes/styles/monokai_sublime.css" id="highlight-theme">
+```
+
 ## License
 [MIT License](http://en.wikipedia.org/wiki/MIT_License)

--- a/app/templates/__index.html
+++ b/app/templates/__index.html
@@ -19,7 +19,7 @@
     <% } %>
 
         <!-- For syntax highlighting -->
-        <link rel="stylesheet" href="bower_components/reveal.js/lib/css/zenburn.css" id="highlight-theme">
+        <link rel="stylesheet" href="bower_components/reveal-highlight-themes/styles/zenburn.css" id="highlight-theme">
 
         <!-- If the query includes 'print-pdf', use the PDF print sheet -->
         <script>

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,6 +2,7 @@
   "name": "<%= _.slugify(config.get('presentationTitle')) %>",
   "version": "<%= config.get('packageVersion') %>",
   "dependencies": {
-    "reveal.js": "~2.6.1"
+    "reveal.js": "~2.6.1",
+    "reveal-highlight-themes": "~8.3.0"
   }
 }


### PR DESCRIPTION
This will pull in the available Highlight.js themes as a Bower dependency and make them available for usage in the presentation.

The available syntax themes can be found in the `bower_components/reveal-highlight-themes/styles` folder and can be selected by changing the stylesheet reference in the `_index.html` file in the generated presentation.
