### PR TITLE
Allow for resource inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ All three options maybe combined, e.g.
 yo reveal:slide "Markdown Slide With Notes And Section-Attributes" --notes --attributes --markdown
 ```
 
+
+
+## Resources
+
+If your presentation requires specific resources that you would like included
+with your project, place them in the resources directory.  These assets will be
+included in the distribution and available for access at the path
+`resources/asset_name.ext`.
+
+
+
 ## Github Pages Deployment
 
 With the help of [Grunt Build Control](https://github.com/robwierzbowski/grunt-build-control), `generator-reveal` can deploy your presentation to Github Pages easily. All you have to do is

--- a/app/index.coffee
+++ b/app/index.coffee
@@ -100,6 +100,8 @@ module.exports = class RevealGenerator extends yeoman.generators.Base
             @copy @templatePath('__index.html'), @destinationPath('templates/_index.html')
             @copy @templatePath('__section.html'), @destinationPath('templates/_section.html')
 
+            @fs.write @destinationPath('resources/.gitkeep'), 'Used to store static assets'
+
         projectfiles: ->
             @fs.copy @templatePath('editorconfig'), @destinationPath('.editorconfig')
             @fs.copy @templatePath('jshintrc'), @destinationPath('.jshintrc')

--- a/app/templates/_Gruntfile.coffee
+++ b/app/templates/_Gruntfile.coffee
@@ -13,6 +13,7 @@ module.exports = (grunt) ->
                     'slides/{,*/}*.{md,html}'
                     'js/*.js'<% if (config.get('useSass')) { %>
                     'css/*.css'<% } %>
+                    'resources/**'
                 ]
 
             index:
@@ -80,6 +81,7 @@ module.exports = (grunt) ->
                         'bower_components/**'
                         'js/**'<% if (config.get('useSass')) { %>
                         'css/*.css'<% } %>
+                        'resources/**'
                     ]
                     dest: 'dist/'
                 },{

--- a/test/test-app-file-creation.coffee
+++ b/test/test-app-file-creation.coffee
@@ -62,6 +62,7 @@ describe 'Generator Reveal', ->
                 'bower.json'
                 'js/loadhtmlslides.js'
                 'package.json'
+                'resources/.gitkeep'
             ]
 
             assert.file expected


### PR DESCRIPTION
Many presentations require static assets to be included with the distribution.  By adding a directory to store resources that is copied with the distribution and watched for reloading, user can now easily include these static resources without modifying their Gruntfile.

For example, it is common to include some sort of image in a presentation.  Since relying on an internet connection during a presentation can be dangerous, someone might place this image file in a directory `img`.  This will work when developing under `grunt serve` but when `grunt dist` is used, the file will not be included.  

This pull request does not create the directory for storing resources because it requires an important design choice.  If an option is preferable that I did not implement, let me know and I can complete the pull request.

1) Leave resource directory creation up to the user.  This is currently what I am doing. Cons: users may overlook this feature.
2) Include a sample image and copy it to the resources directory during generation.  Cons: distribution now includes a random image that is not needed, the project now has a random binary image that is not relevant
3) Create the empty directory.  Cons: requires an extra library ([mkdirp](https://github.com/substack/node-mkdirp) because [mem-fs-editor](https://github.com/SBoudrias/mem-fs-editor) currently does not support this functionality).

Option 3 makes the most sense in terms of usage to me, but requires an additional library.