### PR TITLE
Knowlege of deploy

### DIFF
--- a/app/templates/_Gruntfile.coffee
+++ b/app/templates/_Gruntfile.coffee
@@ -2,6 +2,7 @@
 module.exports = (grunt) ->
 
     grunt.initConfig
+        pkg: grunt.file.readJSON 'package.json'
 
         watch:
 
@@ -101,7 +102,7 @@ module.exports = (grunt) ->
                 message: 'Built from %sourceCommit% on branch %sourceBranch%'
             pages:
                 options:
-                    remote: 'git@github.com:<%= config.get('githubUsername') %>/<%= config.get('githubRepository')%>.git'
+                    remote: '<%%= pkg.repository.url %>'
                     branch: 'gh-pages'
         <% } %>
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,7 +17,12 @@
   "engines": {
     "node": ">=0.10.0",
     "npm": ">=1.3.7"
-  },
+  },<% if (config.get('deployToGithubPages')) { %>
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:<%= config.get('githubUsername') %>/<%= config.get('githubRepository')%>.git"
+
+  },<% } %>
   "scripts": {
     "test": "grunt test"
   }

--- a/test/test-app-file-creation.coffee
+++ b/test/test-app-file-creation.coffee
@@ -130,7 +130,8 @@ describe 'Generator Reveal', ->
                 githubRepository: 'reveal-js'
             )
             .on 'end', ->
-                assert.fileContent 'Gruntfile.coffee', /git@github.com:yeoman\/reveal-js.git/
+                assert.fileContent 'package.json', /git@github.com:yeoman\/reveal-js.git/
+                assert.fileContent 'Gruntfile.coffee', /<\%= pkg.repository.url %>/
                 assert.fileContent 'Gruntfile.coffee', /grunt.registerTask 'deploy'/
                 assert.fileContent 'package.json', /"grunt-build-control"/
                 assert.fileContent '.yo-rc.json', /"githubUsername": "yeoman"/


### PR DESCRIPTION
This will allow for the repository to be put into the package.json— and then the Gruntfile will pull in that from the package.json for deployment. 

Reason: When I copy some slides, I always forget to update that one setting in the not-package.json file— and it would be nice if that would remain in a config file instead of deep in the Gruntfile. 