### PR TITLE
Update grunt-sass dep to ^1.1.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "grunt": "^0.4.5",<% if (config.get('useSass')) { %>
-    "grunt-sass": "^0.14.0",<% } %>
+    "grunt-sass": "^1.1.0",<% } %>
     "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-copy": "^0.8.0",


### PR DESCRIPTION
v0.14.0 does not work because it has node-sass v0.9.0 as a dependency which does not install correctly with current node and npm versions. I just tested this with the current grunt-sass version and it works perfectly.