### PR TITLE
use https i.s.o. git for github repository

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,7 +20,7 @@
   },<% if (config.get('deployToGithubPages')) { %>
   "repository": {
     "type": "git",
-    "url": "git@github.com:<%= config.get('githubUsername') %>/<%= config.get('githubRepository')%>.git"
+    "url": "https://github.com/<%= config.get('githubUsername') %>/<%= config.get('githubRepository')%>"
 
   },<% } %>
   "scripts": {

--- a/test/test-app-file-creation.coffee
+++ b/test/test-app-file-creation.coffee
@@ -130,7 +130,7 @@ describe 'Generator Reveal', ->
                 githubRepository: 'reveal-js'
             )
             .on 'end', ->
-                assert.fileContent 'package.json', /git@github.com:yeoman\/reveal-js.git/
+                assert.fileContent 'package.json', /https:\/\/github.com\/yeoman\/reveal-js/
                 assert.fileContent 'Gruntfile.coffee', /<\%= pkg.repository.url %>/
                 assert.fileContent 'Gruntfile.coffee', /grunt.registerTask 'deploy'/
                 assert.fileContent 'package.json', /"grunt-build-control"/


### PR DESCRIPTION
Is there a reason you generate the github url using the git-protocol? As far as I know there is no authentication possible so it makes it useless to push via this protocol.